### PR TITLE
chore(repo): add GitHub issue templates and contact links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,127 @@
+name: 🐛 Bug Report
+description: Report something that isn't working as expected
+title: "fix(<area>): <short description>"
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report!
+        Please fill in as much information as you can — it helps us reproduce and fix the issue faster.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checks
+      description: Confirm before submitting.
+      options:
+        - label: I searched [existing issues](https://github.com/rendis/statepro/issues?q=is%3Aissue) and this is not a duplicate.
+          required: true
+        - label: I read the [CONTRIBUTING guide](https://github.com/rendis/statepro/blob/main/CONTRIBUTING.md).
+          required: true
+        - label: This is a bug, not a question. (Questions go to [Discussions](https://github.com/rendis/statepro/discussions).)
+          required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Which part of the project is affected?
+      options:
+        - Core (Go library — runtime, theoretical, instrumentation)
+        - Built-in executors (observers, actions, invokes, conditions)
+        - Schema / JSON definition
+        - Debugger (CLI / bot)
+        - Studio — App
+        - Studio — editor-core (@rendis/statepro-studio-react)
+        - Studio — web-component (@rendis/statepro-studio-web-component)
+        - Documentation
+        - Build / tooling / CI
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal, ordered steps that reliably reproduce the bug.
+      placeholder: |
+        1. Define a quantum machine with `...`
+        2. Call `qm.SendEvent(...)` with `...`
+        3. Observe `...`
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened instead? Include error messages or stack traces.
+    validations:
+      required: true
+
+  - type: textarea
+    id: minimal-repro
+    attributes:
+      label: Minimal reproduction
+      description: A minimal Go snippet, JSON definition, or repository link that reproduces the bug. This is the single most useful thing you can provide.
+      render: go
+
+  - type: input
+    id: statepro-version
+    attributes:
+      label: statepro version
+      description: Output of `go list -m github.com/rendis/statepro/v3` — or the npm package version for Studio.
+      placeholder: "v3.2.1"
+    validations:
+      required: true
+
+  - type: input
+    id: go-version
+    attributes:
+      label: Go version
+      description: Output of `go version`. Leave blank if the bug is Studio-only.
+      placeholder: "go1.25.0"
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - WSL
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Any log output, panic traces, or `go test -v` output. Will be auto-formatted as a code block.
+      render: shell
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, related issues, workarounds you've tried, or any other context that might help.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Question or discussion
+    url: https://github.com/rendis/statepro/discussions
+    about: For questions, ideas, and general discussion. Bug reports and feature requests should use the issue templates above.
+  - name: 📖 Documentation
+    url: https://github.com/rendis/statepro/tree/main/docs
+    about: Concepts, modeling guide, runtime, instrumentation, debugging, and best practices.
+  - name: 🔒 Security vulnerability
+    url: https://github.com/rendis/statepro/security/advisories/new
+    about: Report security issues privately via GitHub Security Advisories. Do not open a public issue for vulnerabilities.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,88 @@
+name: ✨ Feature Request
+description: Suggest a new capability, API, or improvement
+title: "feat(<area>): <short description>"
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing an idea!
+        Strong feature requests describe a real problem first and a proposal second.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I searched [existing issues](https://github.com/rendis/statepro/issues?q=is%3Aissue) and this is not a duplicate.
+          required: true
+        - label: I read the [CONTRIBUTING guide](https://github.com/rendis/statepro/blob/main/CONTRIBUTING.md).
+          required: true
+        - label: This is a feature proposal, not a question. (Questions go to [Discussions](https://github.com/rendis/statepro/discussions).)
+          required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - Core (Go library — runtime, theoretical, instrumentation)
+        - Built-in executors (observers, actions, invokes, conditions)
+        - Schema / JSON definition
+        - Debugger (CLI / bot)
+        - Studio — App
+        - Studio — editor-core (@rendis/statepro-studio-react)
+        - Studio — web-component (@rendis/statepro-studio-web-component)
+        - Documentation
+        - Build / tooling / CI
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What pain point or limitation does this address? Describe the problem before proposing a solution.
+      placeholder: When I try to ..., I have to ... because there's no way to ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would this work from the user's perspective? Include API sketches, JSON examples, or UI flows when relevant.
+      placeholder: |
+        Add a method `qm.SomeMethod(...)` that ...
+
+        Example usage:
+        ```go
+        qm.SomeMethod(...)
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches, workarounds, or related libraries you evaluated.
+
+  - type: dropdown
+    id: breaking
+    attributes:
+      label: Is this a breaking change?
+      description: Would this require consumers of statepro to change their code or JSON definitions?
+      options:
+        - "No"
+        - "Yes — breaking change"
+        - "Unsure"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Use cases, related projects, mockups, references, or any background that helps evaluate the proposal.


### PR DESCRIPTION
## Description

Add structured GitHub Issue Forms under `.github/ISSUE_TEMPLATE/` so contributors open well-formed bug reports and feature requests, and route questions, docs lookups, and security reports to the right channels.

### Changes Made

- `.github/ISSUE_TEMPLATE/bug_report.yml` — Issue Form for bugs. Required pre-flight checks, affected area dropdown (Core / built-ins / schema / debugger / Studio packages / docs / CI), description, repro steps, expected vs actual, minimal repro (rendered as Go), statepro version, OS dropdown, optional Go version and logs (rendered as shell), additional context. Auto-applies labels `bug`, `needs-triage`.
- `.github/ISSUE_TEMPLATE/feature_request.yml` — Issue Form for proposals. Required pre-flight checks, affected area, problem statement, proposed solution, breaking-change dropdown (Yes/No/Unsure), optional alternatives and context. Auto-applies labels `enhancement`, `needs-triage`.
- `.github/ISSUE_TEMPLATE/config.yml` — `blank_issues_enabled: false` plus contact links to Discussions (questions), the docs directory (self-service), and GitHub Security Advisories (private vulnerability reporting).

### Best Practices Applied

- Issue Forms (YAML) over legacy Markdown — typed fields with `validations: required: true`.
- `title:` prefixed with Conventional Commits (`fix(<area>):`, `feat(<area>):`).
- Pre-flight checkboxes filter duplicates and route questions to Discussions.
- Required `statepro version` on bug reports — the single biggest triage accelerator for a library.
- `breaking change` dropdown on feature requests — relevant for a SemVer'd library.
- Security vulnerabilities routed to private Security Advisories — no public CVE issues.

### Related Issues

Closes #5

## Type of Change

- [x] Documentation update
- [x] Tooling / repo hygiene

## Verification

- [x] All three YAML files parse cleanly with `yaml.safe_load`.
- [x] Templates render at `https://github.com/rendis/statepro/issues/new/choose` once merged.
- [x] No code changes — Go build/test untouched.

## Checklist

- [x] Code follows the project's style guidelines (N/A — no code)
- [x] Self-review completed
- [x] Documentation updated (N/A — these *are* the docs for new contributors)
- [x] CHANGELOG.md updated under [Unreleased] — N/A: this is repo tooling, not user-visible behavior
- [x] Tests added for new functionality — N/A
- [x] All existing tests pass locally
- [x] No new warnings or errors
- [x] Commit messages follow convention
- [x] Breaking changes documented (none)