### PR TITLE
docs(changelog): close 3.2.2 release section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.2] - 2026-04-25
+
 ### Changed
 
 - **BREAKING**: Replaced `github.com/rendis/abslog/v3` with the standard library
@@ -131,7 +133,8 @@ universes, realities, superposition, observers, and accumulators.
 
 See the GitHub release page for the full v3.0.0 release notes.
 
-[Unreleased]: https://github.com/rendis/statepro/compare/v3.2.1...HEAD
+[Unreleased]: https://github.com/rendis/statepro/compare/v3.2.2...HEAD
+[3.2.2]: https://github.com/rendis/statepro/compare/v3.2.1...v3.2.2
 [3.2.1]: https://github.com/rendis/statepro/compare/v3.2.0...v3.2.1
 [3.2.0]: https://github.com/rendis/statepro/compare/v3.1.1...v3.2.0
 [3.1.1]: https://github.com/rendis/statepro/compare/v3.1.0...v3.1.1


### PR DESCRIPTION
## Summary

- Move all entries under `[Unreleased]` into a new `[3.2.2] - 2026-04-25` section.
- Reset `[Unreleased]` to empty (ready for the next cycle).
- Add the `[3.2.2]` compare link at the bottom and update `[Unreleased]` to compare from `v3.2.2`.

## Why

Tag `v3.2.2` was just pushed (commit `6d95205`, the merge of #12) but the changelog still had those changes under \`[Unreleased]\`. This commit reconciles the changelog with the published tag.

## Out of scope

- Repo-plumbing PRs #6 (issue templates) and #11 (selective agent dir tracking) are intentionally not added — they don't affect the published Go module surface, per Keep a Changelog conventions.

## Follow-up

After merge, the `v3.2.2` tag should be moved forward to the new `main` HEAD so the changelog cut is part of the tagged commit. (Safe to retag — tag was published moments ago.)